### PR TITLE
CI: Bump actions/setup-go to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -34,7 +34,7 @@ jobs:
           bash build.sh dev
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: alist
           path: dist


### PR DESCRIPTION
This mostly bump the Node version to 16，Because GitHub actions will gradually drop Node12.

Link: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Reported-by: Hou Qiyao <houqiyao@ariespan.cn>

Signed-off-by: Hou Qiyao <houqiyao@ariespan.cn>